### PR TITLE
chore: add repr(transparent) to RandomXFlag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ use crate::bindings::{
 
 bitflags! {
     /// RandomX Flags are used to configure the library.
+    #[repr(transparent)]
     pub struct RandomXFlag: u32 {
         /// No flags set. Works on all platforms, but is the slowest.
         const FLAG_DEFAULT      = 0b0000_0000;


### PR DESCRIPTION
It allows generating C bindings with API exposing `RandomXFlag`.